### PR TITLE
Parameterize user ssh and ui access ingress.

### DIFF
--- a/pedl_deploy/templates/simple.yaml
+++ b/pedl_deploy/templates/simple.yaml
@@ -399,6 +399,10 @@ Outputs:
     Description: Id of Master Agent
     Value: !Ref MasterInstance
 
+  MasterPublicIp:
+    Description: Public IP of Master Agent
+    Value: !GetAtt MasterInstance.PublicIp
+
   MasterSecurityGroupId:
     Description: Id of Master Security Group
     Value: !GetAtt MasterSecurityGroup.GroupId

--- a/pedl_deploy/templates/simple.yaml
+++ b/pedl_deploy/templates/simple.yaml
@@ -26,6 +26,11 @@ Parameters:
     Type: String
     Description: Instance Type of Agent
 
+  UserAccessIngress:
+    Type: String
+    Default: 0.0.0.0/0
+    Description: User preferred CIDR block for Master UI and all SSH access
+
 Resources:
   CheckpointBucket:
     Type: AWS::S3::Bucket
@@ -66,7 +71,7 @@ Resources:
       FromPort: 8080
       ToPort: 8080
       IpProtocol: tcp
-      CidrIp: 0.0.0.0/0
+      CidrIp: !Ref UserAccessIngress
 
   MasterSSHIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -75,7 +80,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 22
       ToPort: 22
-      CidrIp: 0.0.0.0/0
+      CidrIp: !Ref UserAccessIngress
 
   AgentSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
@@ -111,7 +116,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 22
       ToPort: 22
-      CidrIp: 0.0.0.0/0
+      CidrIp: !Ref UserAccessIngress
 
   DatabaseEgress:
     Type: AWS::EC2::SecurityGroupEgress

--- a/pedl_deploy/templates/simple.yaml
+++ b/pedl_deploy/templates/simple.yaml
@@ -26,7 +26,7 @@ Parameters:
     Type: String
     Description: Instance Type of Agent
 
-  UserAccessIngress:
+  UserAccessIngressCidr:
     Type: String
     Default: 0.0.0.0/0
     Description: User preferred CIDR block for Master UI and all SSH access
@@ -71,7 +71,7 @@ Resources:
       FromPort: 8080
       ToPort: 8080
       IpProtocol: tcp
-      CidrIp: !Ref UserAccessIngress
+      CidrIp: !Ref UserAccessIngressCidr
 
   MasterSSHIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -80,7 +80,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 22
       ToPort: 22
-      CidrIp: !Ref UserAccessIngress
+      CidrIp: !Ref UserAccessIngressCidr
 
   AgentSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
@@ -116,7 +116,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 22
       ToPort: 22
-      CidrIp: !Ref UserAccessIngress
+      CidrIp: !Ref UserAccessIngressCidr
 
   DatabaseEgress:
     Type: AWS::EC2::SecurityGroupEgress


### PR DESCRIPTION
This gives users option to provide their corporate or VPN CIDR block for ingress access on simple deploy. If they do not wish to provide any, then could default to allow all.